### PR TITLE
Fix pour le chargement des appareils Oneplus

### DIFF
--- a/frameworks/base/packages/SystemUI/res/values-fr/du_strings.xml
+++ b/frameworks/base/packages/SystemUI/res/values-fr/du_strings.xml
@@ -127,8 +127,8 @@
     <string name="omnijaws_package_not_available">OmniJaws indisponible</string>
 
     <!-- Indication on the keyguard that is shown when the device is charging with a dash charger. Should match keyguard_plugged_in_dash_charging [CHAR LIMIT=40]-->
-    <string name="keyguard_indication_dash_charging_time">Chargé à 100 % dans <xliff:g id="charging_time_left" example="4 hours and 2 minutes">%s</xliff:g>)</string>
-    <string name="keyguard_plugged_in_dash_charging">Chargement \"Dash\"</string>
+    <string name="keyguard_indication_dash_charging_time">Charge \"Dash\"… (chargé à 100 %% dans <xliff:g id="charging_time_left">%s</xliff:g>)</string>
+    <string name="keyguard_plugged_in_dash_charging">Charge \"Dash\"…</string>
 
     <!-- Status Bar Brightness Control -->
     <string name="status_bar_toggle_brightness">Réglage de la luminosité</string>


### PR DESCRIPTION
Il y'avait un bug qui rendait impossible le déverrouillage du téléphone lors de la Dash charge 
Ce fix corrige ce bug (Merci à @AirOne70 pour avoir trouver la solution)